### PR TITLE
update ddc.vim version from 0.2.2 to 0.4.2

### DIFF
--- a/denops/ddc-sources/ddc-vim-lsp.ts
+++ b/denops/ddc-sources/ddc-vim-lsp.ts
@@ -1,15 +1,15 @@
 import {
   BaseSource,
   Candidate,
-} from "https://deno.land/x/ddc_vim@v0.2.2/types.ts#^";
+} from "https://deno.land/x/ddc_vim@v0.4.2/types.ts#^";
 
 import {
   Denops,
-} from "https://deno.land/x/ddc_vim@v0.2.2/deps.ts#^";
+} from "https://deno.land/x/ddc_vim@v0.4.2/deps.ts#^";
 
 import {
   once
-} from "https://deno.land/x/denops_std@v1.7.4/anonymous/mod.ts";
+} from "https://deno.land/x/denops_std@v1.8.1/anonymous/mod.ts";
 
 export class Source extends BaseSource {
   async gatherCandidates(args: {


### PR DESCRIPTION
Hi, thanks for making this plugin!

In order to work with the latest ddc.vim, this PR updates ddc.vim to v0.4.2 and denops_std to v1.8.1.