### PR TITLE
Fix: README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ https://github.com/mattn/vim-lsp-settings
         \ })
 ```
 
+ddc.vim remove duplicated keyword by default.
+If you want to list up both of them, please add `'dup': v:true` .
+
 ## Screenshots
 
 <img src="https://user-images.githubusercontent.com/212602/131840821-e3a94117-2eb9-44b9-8da6-3b14ed15b893.png"><br>

--- a/doc/ddc-vim-lsp.txt
+++ b/doc/ddc-vim-lsp.txt
@@ -40,5 +40,8 @@ EXAMPLES                        *ddc-vim-lsp-examples*
         \ })
 <
 
+ddc.vim remove duplicated keyword by default.
+If you want to list up both of them, please add `'dup': v:true` .
+
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:


### PR DESCRIPTION
When a source returns multiple identical candidates, ddc will merge the candidates.
Use the dup option because it may make the snippet unusable
This problem occurs in the fllowing case

![image](https://user-images.githubusercontent.com/45391880/143892287-1fd01116-46a0-4f99-a6fe-c3f0ae4775fc.png)
---
Japanese
ソースが複数の同じ候補を返したときddcは候補をマージします。
スニペットが使えなくなる可能性があるため、dupオプションを利用します
これは下記の様な場合に発生します
![image](https://user-images.githubusercontent.com/45391880/143892186-89110d2d-1d0c-494a-8802-54ca5b0bee4a.png)
