### PR TITLE
use only a server that is the completion provider

### DIFF
--- a/autoload/ddc_vim_lsp.vim
+++ b/autoload/ddc_vim_lsp.vim
@@ -26,3 +26,15 @@ function! ddc_vim_lsp#request(server_name, id) abort
     \ 'on_notification': function('ddc_vim_lsp#_callback', [l:server, l:position, a:id]),
     \ })
 endfunction
+
+
+function! ddc_vim_lsp#get_completion_servers() abort
+  let l:names = []
+  for l:server_name in lsp#get_allowed_servers()
+    let l:capabilities = lsp#get_server_capabilities(l:server_name)
+    if has_key(l:capabilities, 'completionProvider')
+      call add(l:names, l:server_name)
+    endif
+  endfor
+  return l:names
+endfunction

--- a/denops/@ddc-sources/vim-lsp.ts
+++ b/denops/@ddc-sources/vim-lsp.ts
@@ -18,7 +18,7 @@ export class Source extends BaseSource<Params> {
     this.counter = (this.counter + 1) % 100;
 
     const lspservers: string[] = await args.denops.call(
-      "lsp#get_allowed_servers",
+      "ddc_vim_lsp#get_completion_servers",
       // deno-lint-ignore no-explicit-any
     ) as any;
     if (lspservers.length === 0) {


### PR DESCRIPTION
Servers returned from `lsp#get_allowed_servers()` do not have to be the completion provider, and the first element of the returned servers, therefore, may not be the completion provider.

This PR collects only servers that are the completion provider and uses one of the servers for the completion.