### PR TITLE
fix completion for clojure-lsp(check type of results)

### DIFF
--- a/autoload/ddc_vim_lsp.vim
+++ b/autoload/ddc_vim_lsp.vim
@@ -9,7 +9,10 @@ function! ddc_vim_lsp#_callback(server, position, id, data) abort
       \ 'response': a:data['response'],
       \ }
   let lspitems = lsp#omni#get_vim_completion_items(l:options)['items']
-  let isIncomplete = has_key(a:data['response']['result'], 'isIncomplete') ? 
+  let isIncomplete = (
+        \   type(a:data['response']['result']) == 4
+        \   && has_key(a:data['response']['result'], 'isIncomplete')
+        \ ) ?
         \ a:data['response']['result']['isIncomplete'] : v:false
 
   call ddc#callback(a:id, {'items': lspitems, 'isIncomplete': isIncomplete})


### PR DESCRIPTION

Fix #15: `autoload/ddc-vim-lsp.vim:12` to check type of `results` and set `isIncomplete` to `v:false` if it's `list`.

## before
<img width="162" alt="スクリーンショット 2022-08-11 21 45 19" src="https://user-images.githubusercontent.com/378747/184137230-11ef2373-930f-43b4-9033-5a8f6b976acc.png">

## after
<img width="340" alt="スクリーンショット 2022-08-11 21 44 30" src="https://user-images.githubusercontent.com/378747/184137276-ea4692b8-8854-41ff-8a9b-9facf6060864.png">
